### PR TITLE
[Feat] #13: 마이페이지 CRUD 기능구현

### DIFF
--- a/src/main/java/fc/server/palette/member/controller/MemberController.java
+++ b/src/main/java/fc/server/palette/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package fc.server.palette.member.controller;
+
+import fc.server.palette.member.auth.CustomUserDetails;
+import fc.server.palette.member.dto.request.MemberProfileDto;
+import fc.server.palette.member.dto.response.MemberMyPageDto;
+import fc.server.palette.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.cache.spi.support.CacheUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/mypage/{memberId}")
+    public ResponseEntity<?> updateProfile (
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long memberId,
+            @RequestBody MemberProfileDto memberProfileDto
+   ){
+       memberService.updateMember(userDetails.getMember().getId(), memberId, memberProfileDto );
+
+        return ResponseEntity.ok("수정완료");
+    }
+
+
+
+}

--- a/src/main/java/fc/server/palette/member/controller/MemberController.java
+++ b/src/main/java/fc/server/palette/member/controller/MemberController.java
@@ -17,6 +17,12 @@ public class MemberController {
 
     private final MemberService memberService;
 
+
+    @GetMapping("/mypage/{memberId}")
+    public ResponseEntity<?> mypage (@PathVariable Long memberId){
+        return ResponseEntity.ok(memberService.myPageInfo(memberId));
+    }
+
     @PostMapping("/mypage/{memberId}")
     public ResponseEntity<?> updateProfile (
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/fc/server/palette/member/controller/MemberController.java
+++ b/src/main/java/fc/server/palette/member/controller/MemberController.java
@@ -1,7 +1,9 @@
 package fc.server.palette.member.controller;
 
 import fc.server.palette.member.auth.CustomUserDetails;
+import fc.server.palette.member.dto.request.FollowRequestDto;
 import fc.server.palette.member.dto.request.MemberProfileDto;
+import fc.server.palette.member.dto.response.FollowInfoDto;
 import fc.server.palette.member.dto.response.MemberMyPageDto;
 import fc.server.palette.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,8 @@ import org.hibernate.cache.spi.support.CacheUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -33,6 +37,41 @@ public class MemberController {
 
         return ResponseEntity.ok("수정완료");
     }
+
+
+    // 팔로워목록
+    @GetMapping("/mypage/followed/{followedId}")
+    public ResponseEntity<List<FollowInfoDto>> getFollowed(@PathVariable Long followedId) {
+        List<FollowInfoDto> followed = memberService.getFollowed(followedId);
+        return ResponseEntity.ok(followed);
+    }
+
+
+    //팔로잉목록
+    @GetMapping("/mypage/following/{followingId}")
+    public ResponseEntity<List<FollowInfoDto>> getFollowing(@PathVariable Long followingId) {
+        List<FollowInfoDto> following = memberService.getFollowings(followingId);
+        return ResponseEntity.ok(following);
+    }
+
+
+    //팔로우추가
+    @PostMapping("/mypage/follow/{followedId}")
+    public ResponseEntity<?> follow(@PathVariable Long followedId, @RequestBody FollowRequestDto Dto ){
+        memberService.follow(followedId, Dto.getFollowingId());
+        return ResponseEntity.ok("팔로우완료");
+    }
+
+    //팔로우삭제
+    @DeleteMapping("/mypage/follow/{followedId}/{followingId}")
+    public ResponseEntity<?> unfollow(@PathVariable Long followedId, @PathVariable Long followingId) {
+        memberService.unfollow(followedId, followingId);
+        return ResponseEntity.ok("언팔로우완료");
+    }
+
+
+
+
 
 
 

--- a/src/main/java/fc/server/palette/member/controller/MemberController.java
+++ b/src/main/java/fc/server/palette/member/controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
     }
 
 
-    // 팔로워목록
+
     @GetMapping("/mypage/followed/{followedId}")
     public ResponseEntity<List<FollowInfoDto>> getFollowed(@PathVariable Long followedId) {
         List<FollowInfoDto> followed = memberService.getFollowed(followedId);
@@ -47,7 +47,7 @@ public class MemberController {
     }
 
 
-    //팔로잉목록
+
     @GetMapping("/mypage/following/{followingId}")
     public ResponseEntity<List<FollowInfoDto>> getFollowing(@PathVariable Long followingId) {
         List<FollowInfoDto> following = memberService.getFollowings(followingId);
@@ -55,14 +55,14 @@ public class MemberController {
     }
 
 
-    //팔로우추가
+
     @PostMapping("/mypage/follow/{followedId}")
     public ResponseEntity<?> follow(@PathVariable Long followedId, @RequestBody FollowRequestDto Dto ){
         memberService.follow(followedId, Dto.getFollowingId());
         return ResponseEntity.ok("팔로우완료");
     }
 
-    //팔로우삭제
+
     @DeleteMapping("/mypage/follow/{followedId}/{followingId}")
     public ResponseEntity<?> unfollow(@PathVariable Long followedId, @PathVariable Long followingId) {
         memberService.unfollow(followedId, followingId);

--- a/src/main/java/fc/server/palette/member/controller/MemberController.java
+++ b/src/main/java/fc/server/palette/member/controller/MemberController.java
@@ -23,12 +23,12 @@ public class MemberController {
 
 
     @GetMapping("/mypage/{memberId}")
-    public ResponseEntity<?> mypage (@PathVariable Long memberId){
+    public ResponseEntity<?> myPageInfo (@PathVariable Long memberId){
         return ResponseEntity.ok(memberService.myPageInfo(memberId));
     }
 
     @PostMapping("/mypage/{memberId}")
-    public ResponseEntity<?> updateProfile (
+    public ResponseEntity<?> updateMember (
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long memberId,
             @RequestBody MemberProfileDto memberProfileDto
@@ -49,7 +49,7 @@ public class MemberController {
 
 
     @GetMapping("/mypage/following/{followingId}")
-    public ResponseEntity<List<FollowInfoDto>> getFollowing(@PathVariable Long followingId) {
+    public ResponseEntity<List<FollowInfoDto>> getFollowings(@PathVariable Long followingId) {
         List<FollowInfoDto> following = memberService.getFollowings(followingId);
         return ResponseEntity.ok(following);
     }
@@ -68,11 +68,4 @@ public class MemberController {
         memberService.unfollow(followedId, followingId);
         return ResponseEntity.ok("언팔로우완료");
     }
-
-
-
-
-
-
-
 }

--- a/src/main/java/fc/server/palette/member/dto/request/FollowRequestDto.java
+++ b/src/main/java/fc/server/palette/member/dto/request/FollowRequestDto.java
@@ -1,0 +1,14 @@
+package fc.server.palette.member.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowRequestDto {
+    private Long followedId;
+    private Long followingId;
+
+}

--- a/src/main/java/fc/server/palette/member/dto/request/MemberProfileDto.java
+++ b/src/main/java/fc/server/palette/member/dto/request/MemberProfileDto.java
@@ -1,0 +1,30 @@
+package fc.server.palette.member.dto.request;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import fc.server.palette.member.entity.Member;
+import fc.server.palette.member.entity.type.Job;
+import fc.server.palette.member.entity.type.Position;
+import fc.server.palette.member.entity.type.Sex;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberProfileDto {
+    private String image;
+    private String email;
+    private String name;
+    private String phoneNumber;
+
+    @JsonFormat(pattern = "yyyyMMdd")
+    private LocalDate birthday;
+    private String nickname;
+    private String bio;
+    private String sex;
+    private String position;
+    private String job;
+
+}

--- a/src/main/java/fc/server/palette/member/dto/request/MemberProfileDto.java
+++ b/src/main/java/fc/server/palette/member/dto/request/MemberProfileDto.java
@@ -11,8 +11,6 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class MemberProfileDto {
     private String image;
     private String email;

--- a/src/main/java/fc/server/palette/member/dto/response/FollowInfoDto.java
+++ b/src/main/java/fc/server/palette/member/dto/response/FollowInfoDto.java
@@ -1,0 +1,16 @@
+package fc.server.palette.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowInfoDto {
+    private String image;
+    private String nickname;
+    private String bio;
+}

--- a/src/main/java/fc/server/palette/member/dto/response/MemberMyPageDto.java
+++ b/src/main/java/fc/server/palette/member/dto/response/MemberMyPageDto.java
@@ -27,11 +27,9 @@ public class MemberMyPageDto {
 
     private String roomNumber;
 
+    private long followedCount;
 
-
-//    private int followerCount;
-//
-//    private int followedCount;
+    private long followingCount;
 
 
 }

--- a/src/main/java/fc/server/palette/member/dto/response/MemberMyPageDto.java
+++ b/src/main/java/fc/server/palette/member/dto/response/MemberMyPageDto.java
@@ -1,0 +1,37 @@
+package fc.server.palette.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberMyPageDto {
+
+    private String nickname;
+
+    private String image;
+
+    private String bio;
+
+    private String job;
+
+    private String position;
+
+    private String building;
+
+    private String wing;
+
+    private String roomNumber;
+
+
+
+//    private int followerCount;
+//
+//    private int followedCount;
+
+
+}

--- a/src/main/java/fc/server/palette/member/entity/Follow.java
+++ b/src/main/java/fc/server/palette/member/entity/Follow.java
@@ -15,13 +15,14 @@ import javax.persistence.*;
 @Entity
 public class Follow extends BaseEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "followed_id")
     private Member followed;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "following_id")
     private Member following;
 }

--- a/src/main/java/fc/server/palette/member/entity/Member.java
+++ b/src/main/java/fc/server/palette/member/entity/Member.java
@@ -1,6 +1,8 @@
 package fc.server.palette.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import fc.server.palette._common.auditing.BaseEntity;
+import fc.server.palette.member.dto.request.MemberProfileDto;
 import fc.server.palette.member.entity.type.Job;
 import fc.server.palette.member.entity.type.Position;
 import fc.server.palette.member.entity.type.Sex;
@@ -32,12 +34,13 @@ public class Member extends BaseEntity {
     @Column(length = 30)
     private String nickname;
 
-    @Column(name = "phone_number", length = 11)
+    @Column(length = 11)
     private String phoneNumber;
 
     @Column(length = 50)
     private String bio;
 
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthday;
 
     @Enumerated(EnumType.STRING)
@@ -54,15 +57,30 @@ public class Member extends BaseEntity {
     @Column(length = 10)
     private Sex sex;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "office_room_id")
     private Room room;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "building_id")
     private Building building;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "tenant_id")
     private Tenant tenant;
+
+    public void updateProfile(MemberProfileDto dto) {
+        this.image = dto.getImage();
+        this.email = dto.getEmail();
+        this.name = dto.getName();
+        this.phoneNumber = dto.getPhoneNumber();
+        this.birthday = dto.getBirthday();
+        this.nickname = dto.getNickname();
+        this.bio = dto.getBio();
+        this.sex = Sex.fromValue(dto.getSex());
+        this.position = Position.fromOneValue(dto.getPosition());
+        this.job = Job.fromOneValue(dto.getJob());
+    }
+
+
 }

--- a/src/main/java/fc/server/palette/member/entity/type/Job.java
+++ b/src/main/java/fc/server/palette/member/entity/type/Job.java
@@ -1,7 +1,7 @@
 package fc.server.palette.member.entity.type;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import fc.server.palette.meeting.entity.type.Week;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -36,4 +36,15 @@ public enum Job {
         }
         return jobs;
     }
+
+    @JsonCreator
+    public static Job fromOneValue(String value) {
+        for (Job job : Job.values()) {
+            if (job.getValue().equals(value)) {
+                return job;
+            }
+        }
+        throw new IllegalArgumentException("Invalid job: " + value);
+    }
+
 }

--- a/src/main/java/fc/server/palette/member/entity/type/Position.java
+++ b/src/main/java/fc/server/palette/member/entity/type/Position.java
@@ -31,4 +31,14 @@ public enum Position {
         }
         return positions;
     }
+
+    @JsonCreator
+    public static Position fromOneValue(String value) {
+        for (Position position : Position.values()) {
+            if (position.getValue().equals(value)) {
+                return position;
+            }
+        }
+        throw new IllegalArgumentException("Invalid position: " + value);
+    }
 }

--- a/src/main/java/fc/server/palette/member/entity/type/Sex.java
+++ b/src/main/java/fc/server/palette/member/entity/type/Sex.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Sex {
+
     FEMALE("여성"), MALE("남성"), IRRELEVANT("무관");
 
     private final String value;

--- a/src/main/java/fc/server/palette/member/repository/BuildingRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/BuildingRepository.java
@@ -1,0 +1,7 @@
+package fc.server.palette.member.repository;
+
+import fc.server.palette.member.entity.Building;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuildingRepository extends JpaRepository<Building, Long> {
+}

--- a/src/main/java/fc/server/palette/member/repository/FollowRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/FollowRepository.java
@@ -1,0 +1,8 @@
+package fc.server.palette.member.repository;
+
+
+import fc.server.palette.member.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+}

--- a/src/main/java/fc/server/palette/member/repository/FollowRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/FollowRepository.java
@@ -2,7 +2,20 @@ package fc.server.palette.member.repository;
 
 
 import fc.server.palette.member.entity.Follow;
+import fc.server.palette.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    List<Follow> findByFollowing(Member following);
+    List<Follow> findByFollowed(Member followed);
+
+    Optional<Follow> findByFollowingAndFollowed(Member following, Member followed);
+
+    long countByFollowed_Id(Long memberId);
+
+    long countByFollowing_Id(Long memberId);
 }

--- a/src/main/java/fc/server/palette/member/repository/FollowRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/FollowRepository.java
@@ -4,18 +4,24 @@ package fc.server.palette.member.repository;
 import fc.server.palette.member.entity.Follow;
 import fc.server.palette.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
-    List<Follow> findByFollowing(Member following);
-    List<Follow> findByFollowed(Member followed);
+    List<Follow> findByFollowedId(Long followedId);
+    List<Follow> findByFollowingId(Long followingId);
 
-    Optional<Follow> findByFollowingAndFollowed(Member following, Member followed);
+    Optional<Follow> findByFollowedIdAndFollowingId(Long followedId, Long followingId);
 
-    long countByFollowed_Id(Long memberId);
+    @Modifying
+    @Transactional
+    void deleteByFollowedIdAndFollowingId(Long followedId, Long followingId);
 
-    long countByFollowing_Id(Long memberId);
+    long countByFollowedId(Long memberId);
+
+    long countByFollowingId(Long memberId);
 }

--- a/src/main/java/fc/server/palette/member/repository/MemberRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/MemberRepository.java
@@ -7,5 +7,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findById(Long memberId);
     Optional<Member> findByEmail(String email);
+
+
 }

--- a/src/main/java/fc/server/palette/member/repository/RoomRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/RoomRepository.java
@@ -1,0 +1,8 @@
+package fc.server.palette.member.repository;
+
+
+import fc.server.palette.member.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/fc/server/palette/member/repository/TenantRepository.java
+++ b/src/main/java/fc/server/palette/member/repository/TenantRepository.java
@@ -1,0 +1,9 @@
+package fc.server.palette.member.repository;
+
+
+import fc.server.palette.member.entity.Tenant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantRepository extends JpaRepository<Tenant, Long> {
+
+}

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -4,7 +4,10 @@ import fc.server.palette._common.exception.Exception400;
 import fc.server.palette._common.exception.Exception403;
 import fc.server.palette._common.exception.message.ExceptionMessage;
 import fc.server.palette.member.dto.request.MemberProfileDto;
+import fc.server.palette.member.dto.response.MemberMyPageDto;
+import fc.server.palette.member.entity.Building;
 import fc.server.palette.member.entity.Member;
+import fc.server.palette.member.entity.Room;
 import fc.server.palette.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,9 +31,33 @@ public class MemberService {
 
     }
 
+    public MemberMyPageDto myPageInfo(Long memberId) {
+        Optional<Member> memberOptional = Optional.ofNullable(memberRepository.findById(memberId).orElseThrow(
+                () -> new Exception400(memberId.toString(), ExceptionMessage.NO_MEMBER_ID)));
+
+        if (memberOptional.isPresent()) {
+            Member member = memberOptional.get();
+
+            Optional<Building> buildingOptional = Optional.ofNullable(member.getBuilding());
+            Optional<Room> roomOptional = Optional.ofNullable(member.getRoom());
 
 
+            return MemberMyPageDto.builder()
+                    .nickname(member.getNickname() != null ? member.getNickname() : member.getName())
+                    .image(member.getImage())
+                    .bio(member.getBio())
+                    .job(member.getJob() != null ? member.getJob().getValue() : null)
+                    .position(member.getPosition() != null ? member.getPosition().getValue() : null)
+                    .building(buildingOptional.map(Building::getName).orElse(null))
+                    .wing(roomOptional.map(Room::getWing).orElse(null))
+                    .roomNumber(roomOptional.map(Room::getRoomNumber).orElse(null))
+                    .build();
+        } else {
+            return null;
+        }
 
+
+    }
 }
 
 

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -4,21 +4,29 @@ import fc.server.palette._common.exception.Exception400;
 import fc.server.palette._common.exception.Exception403;
 import fc.server.palette._common.exception.message.ExceptionMessage;
 import fc.server.palette.member.dto.request.MemberProfileDto;
+import fc.server.palette.member.dto.response.FollowInfoDto;
 import fc.server.palette.member.dto.response.MemberMyPageDto;
 import fc.server.palette.member.entity.Building;
+import fc.server.palette.member.entity.Follow;
 import fc.server.palette.member.entity.Member;
 import fc.server.palette.member.entity.Room;
+import fc.server.palette.member.repository.FollowRepository;
 import fc.server.palette.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
     @Transactional
     public void updateMember(Long loginMemberId, Long memberId, MemberProfileDto memberProfileDto){
         Member member = memberRepository.findById(memberId).orElseThrow(
@@ -31,6 +39,7 @@ public class MemberService {
 
     }
 
+
     public MemberMyPageDto myPageInfo(Long memberId) {
         Optional<Member> memberOptional = Optional.ofNullable(memberRepository.findById(memberId).orElseThrow(
                 () -> new Exception400(memberId.toString(), ExceptionMessage.NO_MEMBER_ID)));
@@ -40,6 +49,10 @@ public class MemberService {
 
             Optional<Building> buildingOptional = Optional.ofNullable(member.getBuilding());
             Optional<Room> roomOptional = Optional.ofNullable(member.getRoom());
+
+            // 팔로워 수와 팔로우 수 조회
+            long followedCount = getFollowedCount(memberId);
+            long followingCount = getFollowingCount(memberId);
 
 
             return MemberMyPageDto.builder()
@@ -51,13 +64,26 @@ public class MemberService {
                     .building(buildingOptional.map(Building::getName).orElse(null))
                     .wing(roomOptional.map(Room::getWing).orElse(null))
                     .roomNumber(roomOptional.map(Room::getRoomNumber).orElse(null))
+                    .followedCount(followedCount) // 팔로워 수 설정
+                    .followingCount(followingCount) // 팔로우 수 설정
                     .build();
         } else {
             return null;
         }
 
-
     }
+
+    // 팔로워 수 조회
+    public long getFollowedCount(Long memberId) {
+        return followRepository.countByFollowed_Id(memberId);
+    }
+
+    // 팔로우 수 조회
+    public long getFollowingCount(Long memberId) {
+        return followRepository.countByFollowing_Id(memberId);
+    }
+
+
 }
 
 

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -1,0 +1,41 @@
+package fc.server.palette.member.service;
+
+import fc.server.palette._common.exception.Exception400;
+import fc.server.palette._common.exception.Exception403;
+import fc.server.palette._common.exception.message.ExceptionMessage;
+import fc.server.palette.member.dto.request.MemberProfileDto;
+import fc.server.palette.member.entity.Member;
+import fc.server.palette.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    @Transactional
+    public void updateMember(Long loginMemberId, Long memberId, MemberProfileDto memberProfileDto){
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new Exception400(memberId.toString(), ExceptionMessage.NO_MEMBER_ID));
+        if (member.getId() != loginMemberId) {
+            throw new Exception403(ExceptionMessage.ACCESS_DENIED);
+        }
+
+        member.updateProfile(memberProfileDto);
+
+    }
+
+
+
+
+}
+
+
+
+
+
+
+

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -40,16 +40,14 @@ public class MemberService {
 
     }
 
-
     public MemberMyPageDto myPageInfo(Long memberId) {
-        Optional<Member> memberOptional = Optional.ofNullable(memberRepository.findById(memberId).orElseThrow(
-                () -> new Exception400(memberId.toString(), ExceptionMessage.NO_MEMBER_ID)));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new Exception400(memberId.toString(), ExceptionMessage.NO_MEMBER_ID));
 
-        if (memberOptional.isPresent()) {
-            Member member = memberOptional.get();
+        if (member!= null) {
 
-            Optional<Building> buildingOptional = Optional.ofNullable(member.getBuilding());
-            Optional<Room> roomOptional = Optional.ofNullable(member.getRoom());
+            Building building = member.getBuilding();
+            Room room = member.getRoom();
 
 
             long followedCount = getFollowedCount(memberId);
@@ -62,9 +60,9 @@ public class MemberService {
                     .bio(member.getBio())
                     .job(member.getJob() != null ? member.getJob().getValue() : null)
                     .position(member.getPosition() != null ? member.getPosition().getValue() : null)
-                    .building(buildingOptional.map(Building::getName).orElse(null))
-                    .wing(roomOptional.map(Room::getWing).orElse(null))
-                    .roomNumber(roomOptional.map(Room::getRoomNumber).orElse(null))
+                    .building(building.getName())
+                    .wing(room.getWing())
+                    .roomNumber(room.getRoomNumber())
                     .followedCount(followedCount)
                     .followingCount(followingCount)
                     .build();
@@ -73,11 +71,6 @@ public class MemberService {
         }
 
     }
-
-
-
-
-
     public long getFollowedCount(Long memberId) {
         return followRepository.countByFollowedId(memberId);
     }
@@ -148,10 +141,5 @@ public class MemberService {
 
 
 }
-
-
-
-
-
 
 

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -51,7 +51,7 @@ public class MemberService {
             Optional<Building> buildingOptional = Optional.ofNullable(member.getBuilding());
             Optional<Room> roomOptional = Optional.ofNullable(member.getRoom());
 
-            // 팔로워 수와 팔로우 수 조회
+
             long followedCount = getFollowedCount(memberId);
             long followingCount = getFollowingCount(memberId);
 
@@ -65,8 +65,8 @@ public class MemberService {
                     .building(buildingOptional.map(Building::getName).orElse(null))
                     .wing(roomOptional.map(Room::getWing).orElse(null))
                     .roomNumber(roomOptional.map(Room::getRoomNumber).orElse(null))
-                    .followedCount(followedCount) // 팔로워 수 설정
-                    .followingCount(followingCount) // 팔로우 수 설정
+                    .followedCount(followedCount)
+                    .followingCount(followingCount)
                     .build();
         } else {
             return null;
@@ -77,18 +77,18 @@ public class MemberService {
 
 
 
-    // 팔로워 수 조회
+
     public long getFollowedCount(Long memberId) {
         return followRepository.countByFollowedId(memberId);
     }
 
-    // 팔로우 수 조회
+
     public long getFollowingCount(Long memberId) {
         return followRepository.countByFollowingId(memberId);
     }
 
 
-    //팔로우하는 메서드
+
     public void follow(Long followedId, Long followingId) {
         Optional<Follow> existingFollow = followRepository.findByFollowedIdAndFollowingId(followedId, followingId);
         if (existingFollow.isEmpty()) {
@@ -100,7 +100,7 @@ public class MemberService {
         }
     }
 
-    //언팔로우 메서드
+
     public void unfollow(Long followedId, Long followingId) {
         Optional<Follow> existingFollow = followRepository.findByFollowedIdAndFollowingId(followedId, followingId);
         existingFollow.ifPresent(follow ->  {
@@ -108,7 +108,7 @@ public class MemberService {
         });
     }
 
-    //팔로워 회원 목록 조회
+
     public List<FollowInfoDto> getFollowed(Long memberId) {
         List<Follow> followerList = followRepository.findByFollowedId(memberId);
         List<FollowInfoDto> followerInfoList = new ArrayList<>();
@@ -122,7 +122,7 @@ public class MemberService {
         return followerInfoList;
     }
 
-    // 팔로잉 리스트 조회 메서드
+
     public List<FollowInfoDto> getFollowings(Long memberId) {
         List<Follow> followingList = followRepository.findByFollowingId(memberId);
         List<FollowInfoDto> followingInfoList = new ArrayList<>();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,6 +6,8 @@ server:
       force: true
 
 spring:
+  jackson:
+    default-property-inclusion: ALWAYS
   datasource:
     url: jdbc:h2:mem:test;MODE=MySQL;
     driver-class-name: org.h2.Driver
@@ -18,6 +20,7 @@ spring:
   #    driver-class-name: com.mysql.cj.jdbc.Driver
   #    username: root
   #    password: root1234
+
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## 🧑‍💻 요약
- 마이페이지 기능구현

## ✅ 작업 내용
- [x] 마이페이지 메인
- [ ] 상대방이 보는 마이페이지
- [x] 마이페이지 프로필 수정
- [x] 친구목록(팔로워, 팔로우)

## 참고 사항
-메인은 현재 하단 리스트를 제외하고 상단부기능만 구현했습니다(nickname, bio, job, position, followercount, followingcount)
-피그마상 상대방이 보는마이페이지도 별반다르지 않지만(들어가는 버튼만달라짐) 동일한 api를 사용해도 될지 고민입니다.(해서 해당 작업체크는 애매해서 비워놨습니다.)
-팔로워,팔로우 리스트가 나오게끔 구현했습니다만 한번 확인이 필요할꺼같습니다.
## 관련이슈
#13 

