### PR TITLE
[Feat] #27 채팅 정보 조회, 퇴장 기능 구현

### DIFF
--- a/src/main/java/fc/server/palette/chat/controller/ChatController.java
+++ b/src/main/java/fc/server/palette/chat/controller/ChatController.java
@@ -1,8 +1,11 @@
 package fc.server.palette.chat.controller;
 
+import fc.server.palette.chat.dto.request.ChatRoomNoticeRequestDto;
 import fc.server.palette.chat.entity.ChatMessage;
-import fc.server.palette.chat.service.ChatService;
+import fc.server.palette.chat.entity.ChatRoom;
+import fc.server.palette.chat.entity.type.ChatRoomType;
 import fc.server.palette.chat.service.ChatRoomService;
+import fc.server.palette.chat.service.ChatService;
 import fc.server.palette.member.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +16,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/chat")
@@ -29,7 +29,7 @@ public class ChatController {
 
     //채팅방 목록 조회
     @GetMapping("/list")
-    public ResponseEntity<?> getChatRoomList(@RequestParam("type") String type, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> chatRoomList(@RequestParam("type") String type, @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberId = userDetails.getMember().getId();
 
         if (type.equals("p")) {
@@ -38,6 +38,45 @@ public class ChatController {
 
         return ResponseEntity.ok(chatMessageService.setChatRoomListResponse(chatRoomService.findGroupChatRoomList(memberId), memberId));
     }
+
+    //공지 등록
+    @PostMapping("/notice")
+    public ResponseEntity<?> noticeSave(@RequestBody ChatRoomNoticeRequestDto request) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(request.getRoomId());
+        chatRoom.getNoticeList().add(request.getMessageId());
+        chatRoomService.updateChatRoom(chatRoom);
+
+        return ResponseEntity.ok(request);
+    }
+
+    //공지 리스트 조회
+    //TODO memberimageUrl 추가 로직
+    @GetMapping("/notice")
+    public ResponseEntity<?> noticeList(@RequestParam("roomId") String roomId) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+
+        return ResponseEntity.ok(chatMessageService.setChatRoomNoticeListResponse(chatRoom));
+    }
+
+    //채팅방 나가기
+    @DeleteMapping("/exit")
+    public ResponseEntity<?> memberRemove(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam("roomId") String roomId) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+        chatRoom.getMemberList().remove(userDetails.getMember().getId());
+        chatRoom.getExitList().remove(userDetails.getMember().getId());
+
+        if (chatRoom.getType().equals(ChatRoomType.MEETING) || chatRoom.getType().equals(ChatRoomType.PURCHASE)) {
+            //TODO 채팅방에 나갔습니다 메세지 발송
+        }
+
+        chatRoomService.updateChatRoom(chatRoom);
+
+        return ResponseEntity.ok("삭제되었습니다");
+    }
+
+    /**
+     * related to Socket
+     */
 
     @MessageMapping("/chat/send")
     @SendTo("/sub/public/{roomId}")

--- a/src/main/java/fc/server/palette/chat/dto/request/ChatRoomNoticeRequestDto.java
+++ b/src/main/java/fc/server/palette/chat/dto/request/ChatRoomNoticeRequestDto.java
@@ -1,0 +1,9 @@
+package fc.server.palette.chat.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomNoticeRequestDto {
+    private String roomId;
+    private String messageId;
+}

--- a/src/main/java/fc/server/palette/chat/dto/response/ChatRoomDetailContentResponseDto.java
+++ b/src/main/java/fc/server/palette/chat/dto/response/ChatRoomDetailContentResponseDto.java
@@ -1,0 +1,16 @@
+package fc.server.palette.chat.dto.response;
+
+import fc.server.palette.chat.entity.type.ChatRoomType;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ChatRoomDetailContentResponseDto {
+    private Long contentId;
+    private String title;
+    private List<Object> tag;
+    private String image;
+    private Object week;
+    private ChatRoomType type;
+}

--- a/src/main/java/fc/server/palette/chat/dto/response/ChatRoomDetailResponseDto.java
+++ b/src/main/java/fc/server/palette/chat/dto/response/ChatRoomDetailResponseDto.java
@@ -1,0 +1,10 @@
+package fc.server.palette.chat.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomDetailResponseDto {
+    private Long host;
+    private String notice;
+    private ChatRoomDetailContentResponseDto contentNotice;
+}

--- a/src/main/java/fc/server/palette/chat/dto/response/ChatRoomListResponseDto.java
+++ b/src/main/java/fc/server/palette/chat/dto/response/ChatRoomListResponseDto.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 @Builder
 public class ChatRoomListResponseDto {
     private String id;

--- a/src/main/java/fc/server/palette/chat/dto/response/ChatRoomListResponseDto.java
+++ b/src/main/java/fc/server/palette/chat/dto/response/ChatRoomListResponseDto.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
+@Setter
 @Builder
 public class ChatRoomListResponseDto {
     private String id;
     private String title;
     private String image;
-    private List<Long> memberList;
+    private Integer members;
     private String recentMessage;
     private LocalDateTime recentTime;
     private Long unRead;

--- a/src/main/java/fc/server/palette/chat/dto/response/ChatRoomNoticeListResponseDto.java
+++ b/src/main/java/fc/server/palette/chat/dto/response/ChatRoomNoticeListResponseDto.java
@@ -1,0 +1,19 @@
+package fc.server.palette.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class ChatRoomNoticeListResponseDto {
+    private String noticeId;
+    private String notice;
+    private Long memberId;
+    private String profileImgUrl;
+    private LocalDateTime createdAt;
+    private Long host;
+}

--- a/src/main/java/fc/server/palette/chat/entity/ChatRoom.java
+++ b/src/main/java/fc/server/palette/chat/entity/ChatRoom.java
@@ -20,7 +20,7 @@ public class ChatRoom {
     private String title;
     private String thumbnail;
     private Long host;
-    private List<String> notice;
+    private List<String> noticeList;
     private Long contentId;
     private List<Long> memberList;
     private Map<Long, LocalDateTime> exitList;
@@ -28,5 +28,6 @@ public class ChatRoom {
     public ChatRoom() {
         this.memberList = new ArrayList<>();
         this.exitList = new HashMap<>();
+        this.noticeList = new ArrayList<>();
     }
 }

--- a/src/main/java/fc/server/palette/chat/entity/type/ChatMessageType.java
+++ b/src/main/java/fc/server/palette/chat/entity/type/ChatMessageType.java
@@ -11,5 +11,6 @@ public enum ChatMessageType {
     LEAVE,
     IMAGE,
     FILE,
-    SHARE
+    SHARE,
+    SYSTEM
 }

--- a/src/main/java/fc/server/palette/chat/service/ChatRoomService.java
+++ b/src/main/java/fc/server/palette/chat/service/ChatRoomService.java
@@ -21,19 +21,34 @@ public class ChatRoomService {
         return savedRoom.getId();
     }
 
+    //개인 톡방 조회
     @Transactional
     public List<ChatRoom> findPersonalChatRoomList(Long memberId) {
         return chatRoomRepository.findPersonalRoomByMemberId(memberId);
     }
 
+    //단체 톡방 조회
     @Transactional
     public List<ChatRoom> findGroupChatRoomList(Long memberId) {
         return chatRoomRepository.findGroupRoomByMemberId(memberId);
     }
 
+    //roomId로 채팅방 조회
+    @Transactional
+    public ChatRoom findChatRoomById(String roomId) {
+        return chatRoomRepository.findChatRoomById(roomId);
+    }
+
+    //ChatRoom 정보 업데이트
+    @Transactional
+    public void updateChatRoom(ChatRoom chatRoom) {
+        chatRoomRepository.save(chatRoom);
+    }
+
+    //소켓 연결 해제 시 시간 정보 업데이트
     @Transactional
     public void updateChatRoomExitTime(Long memberId, String roomId) {
-        ChatRoom chatRoom = chatRoomRepository.findChatRoomById(roomId);
+        ChatRoom chatRoom = findChatRoomById(roomId);
         chatRoom.getExitList().put(memberId, LocalDateTime.now());
         chatRoomRepository.save(chatRoom);
     }

--- a/src/main/java/fc/server/palette/chat/service/ChatService.java
+++ b/src/main/java/fc/server/palette/chat/service/ChatService.java
@@ -1,6 +1,7 @@
 package fc.server.palette.chat.service;
 
 import fc.server.palette.chat.dto.response.ChatRoomListResponseDto;
+import fc.server.palette.chat.dto.response.ChatRoomNoticeListResponseDto;
 import fc.server.palette.chat.entity.ChatMessage;
 import fc.server.palette.chat.entity.ChatRoom;
 import fc.server.palette.chat.repository.ChatMessageRepository;
@@ -19,27 +20,15 @@ public class ChatService {
 
     private final ChatMessageRepository chatMessageRepository;
 
-    //Dto에 정보를 설정하는 메소드
+    //채팅 저장
     @Transactional
-    public List<ChatRoomListResponseDto> setChatRoomListResponse(List<ChatRoom> chatRoomList, Long memberId) {
-        List<ChatRoomListResponseDto> chatRoomResponseList = new ArrayList<>();
-        for (ChatRoom rooms : chatRoomList) {
-            LocalDateTime exitedAt = rooms.getExitList().get(memberId);
-            ChatRoomListResponseDto response = ChatRoomListResponseDto.builder()
-                    .id(rooms.getId())
-                    .title(rooms.getTitle())
-                    .image(rooms.getThumbnail())
-                    .memberList(rooms.getMemberList())
-                    .unRead(countRecentMessages(memberId, rooms.getId(), exitedAt))
-                    .build();
-            Optional<ChatMessage> message = findRecentMessage(rooms.getId());
-            if (message.isPresent()) {
-                response.setRecentMessage(message.get().getContent());
-                response.setRecentTime(message.get().getCreatedAt());
-            }
-            chatRoomResponseList.add(response);
-        }
-        return chatRoomResponseList;
+    public void saveChat(ChatMessage chatMessage) {
+        chatMessageRepository.save(chatMessage);
+    }
+
+    @Transactional
+    public Optional<ChatMessage> findChatMessageById(String msgId) {
+        return chatMessageRepository.findById(msgId);
     }
 
     @Transactional
@@ -52,8 +41,48 @@ public class ChatService {
         return chatMessageRepository.countRecentMessages(memberId, roomId, time);
     }
 
+    //ChatRoomListDto에 정보를 설정하는 메소드
     @Transactional
-    public void saveChat(ChatMessage chatMessage) {
-        chatMessageRepository.save(chatMessage);
+    public List<ChatRoomListResponseDto> setChatRoomListResponse(List<ChatRoom> chatRoomList, Long memberId) {
+        List<ChatRoomListResponseDto> chatRoomResponseList = new ArrayList<>();
+        for (ChatRoom rooms : chatRoomList) {
+            LocalDateTime exitedAt = rooms.getExitList().get(memberId);
+            ChatRoomListResponseDto response = ChatRoomListResponseDto.builder()
+                    .id(rooms.getId())
+                    .title(rooms.getTitle())
+                    .image(rooms.getThumbnail())
+                    .members(rooms.getMemberList().size())
+                    .unRead(countRecentMessages(memberId, rooms.getId(), exitedAt))
+                    .build();
+            Optional<ChatMessage> message = findRecentMessage(rooms.getId());
+            if (message.isPresent()) {
+                response.setRecentMessage(message.get().getContent());
+                response.setRecentTime(message.get().getCreatedAt());
+            }
+            chatRoomResponseList.add(response);
+        }
+        return chatRoomResponseList;
     }
+
+    //ChatRoomNoticeListDto에 정보를 설정하는 메소드
+    @Transactional
+    public List<ChatRoomNoticeListResponseDto> setChatRoomNoticeListResponse(ChatRoom chatRoom) {
+        List<ChatRoomNoticeListResponseDto> chatRoomNoticeResponseList = new ArrayList<>();
+        for (String noticeId : chatRoom.getNoticeList()) {
+            ChatRoomNoticeListResponseDto response = ChatRoomNoticeListResponseDto
+                    .builder()
+                    .host(chatRoom.getHost())
+                    .build();
+            Optional<ChatMessage> message = findChatMessageById(noticeId);
+            if (message.isPresent()) {
+                response.setNoticeId(message.get().getId());
+                response.setNotice(message.get().getContent());
+                response.setMemberId(message.get().getSender());
+                response.setCreatedAt(message.get().getCreatedAt());
+            }
+            chatRoomNoticeResponseList.add(response);
+        }
+        return chatRoomNoticeResponseList;
+    }
+
 }


### PR DESCRIPTION
## 🧑‍💻 요약
- 채팅방 리스트 조회 (refactor)
- 채팅방 공지 리스트 조회
- 채팅방 나가기
- 채팅방 컨텐츠 정보 + 채팅방 입장 로직 병합
- 채팅방 유저 목록 조회

## ✅ 작업 내용
- [x] 채팅방 리스트 조회 (refactor)
- [x] 채팅방 공지 리스트 조회
- [x] 채팅방 나가기
- [ ] 채팅방 컨텐츠 정보 + 채팅방 입장 로직 병합
- [ ] 채팅방 유저 목록 조회

## 참고 사항
- 유저 관련 정보 가져오는 부분 제외 구현
- MessageType -> SYSTEM 추가, 단체톡에서 퇴장 시 알림 메세지를 저장하기 위해 System 타입을 추가했습니다.
- 채팅방 입장 시 Session 정보 설정은 메소드만 만들어 두고 자바스크립트 코드로 설정해야할 것 같습니다..
## 관련 이슈
Close #27