### PR TITLE
[Feat] #33 S3 이미지 저장 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation platform('software.amazon.awssdk:bom:2.20.56')
+    implementation 'software.amazon.awssdk:core:2.20.153'
+    implementation 'software.amazon.awssdk:s3'
 //    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 //    testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/fc/server/palette/_common/s3/S3Config.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3Config.java
@@ -1,0 +1,30 @@
+package fc.server.palette._common.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    @Value("${s3.access-key}")
+    private String accessKey;
+
+    @Value("${s3.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client defaultS3Client() {
+        AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(credentials);
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+}

--- a/src/main/java/fc/server/palette/_common/s3/S3DirectoryNames.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3DirectoryNames.java
@@ -1,0 +1,9 @@
+package fc.server.palette._common.s3;
+
+public class S3DirectoryNames {
+    public static final String CHAT = "chat";
+    public static final String MEETING = "meeting";
+    public static final String PURCHASE = "purchase";
+    public static final String SECONDHAND = "secondhand";
+    public static final String MEMBER = "member";
+}

--- a/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
@@ -1,0 +1,54 @@
+package fc.server.palette._common.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageUploader {
+    @Value("${s3.bucket-name}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+
+    //컨트롤러로 부터 이미지를 받는 메서드
+
+    /**
+     * @param directory s3 내 디렉토릭 될 각 도메인의 이름 ex)purchase
+     * @param images    요청으로 받은 이미지 리스트
+     * @return 이미지의 저장경로 즉, URL이 담긴 리스트
+     * @throws IOException
+     */
+    public List<String> save(String directory, List<MultipartFile> images) throws IOException {
+        List<String> paths = new ArrayList<>();
+
+        for (MultipartFile image : images) {
+            InputStream inputStream = image.getInputStream();
+            String path = directory + "/" + image.getOriginalFilename();
+
+            paths.add(path);
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(path)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, inputStream.available()));
+
+            inputStream.close();
+        }
+
+        return paths;
+    }
+}
+


### PR DESCRIPTION
## 🧑‍💻 요약
- S3연동 및 컨트롤러에서 호출하여 사용하도록 이미지 저장 로직구현했습니다. 
- 메서드의 인자는 (String directory, List<MultipartFile> images)이며 첫번째 인자는 본인 도메인 이름을 의미합니다. 저장소 내 디렉토리로 도메인별 이미지를 구분하기 위해 받는 값입니다. 두번째 인자는 이미지 파일 리스트입니다. 

## ✅ 작업 내용
- [x] S3 연동
- [x] 이미지 저장 메서드 구현

## 참고 사항
도메인 이름의 enum이나 상수로 만들어 관리하는게 필요할까요? 상수나 enum 컨벤션은 대문자인데 이 값을 그대로 경로명으로 사용하게되면 문제가 있진 않을까하는 생각에 만들어 놓지는 않았습니다.

## 관련 이슈
Close #33 