### PR TITLE
[Feat] #48 S3 삭제 기능 구현 완료

### DIFF
--- a/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
@@ -38,26 +38,28 @@ public class S3ImageUploader {
      * @return 이미지의 저장경로 즉, URL이 담긴 리스트
      * @throws IOException
      */
-    public List<String> save(String directory, List<MultipartFile> images) throws IOException {
+    public List<String> save(String directory, List<MultipartFile> images) {
         List<String> paths = new ArrayList<>();
 
-        for (MultipartFile image : images) {
-            InputStream inputStream = image.getInputStream();
-            String path = directory + "/" + image.getOriginalFilename();
+        try {
+            for (MultipartFile image : images) {
+                InputStream inputStream = image.getInputStream();
+                String path = directory + "/" + image.getOriginalFilename();
 
-            paths.add(endPoint + path);
+                paths.add(endPoint + path);
 
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(path)
-                    .build();
+                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(path)
+                        .build();
 
-            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, inputStream.available()));
+                s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, inputStream.available()));
 
-            inputStream.close();
+                inputStream.close();
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
-        s3Client.close();
-
         return paths;
     }
 

--- a/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -52,6 +53,13 @@ public class S3ImageUploader {
         }
 
         return paths;
+    }
+
+    private List<String> removeEndpoint(List<String> urls) {
+        return urls
+                .stream()
+                .map(url -> url.replace(endPoint, ""))
+                .collect(Collectors.toList());
     }
 }
 

--- a/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
@@ -16,6 +16,9 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class S3ImageUploader {
+    @Value("${s3.end-point}")
+    private String endPoint;
+    
     @Value("${s3.bucket-name}")
     private String bucketName;
 

--- a/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class S3ImageUploader {
     @Value("${s3.end-point}")
     private String endPoint;
-    
+
     @Value("${s3.bucket-name}")
     private String bucketName;
 
@@ -39,7 +39,7 @@ public class S3ImageUploader {
             InputStream inputStream = image.getInputStream();
             String path = directory + "/" + image.getOriginalFilename();
 
-            paths.add(path);
+            paths.add(endPoint + path);
 
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)


### PR DESCRIPTION
## 🧑‍💻 요약
- 사용자가 게시글 수정 시 기존에 올렸던 이미지를 삭제하는 경우 저장소 내 이미지를 삭제할 수 있도록 기능 구현했습니다.

## ✅ 작업 내용
- [x] 엔드포인트 상수 선언(http://fc-palette.s3-website.ap-northeast-2.amazonaws.com/)
- [x] S3저장 후 **엔드포인트 상수 + 도메인 이름 + 파일이름** 형식으로 리턴하도록 수정
- [x] 삭제할 이미지 경로를 리스트로 받아 경로명에서 상수를 제거한 뒤 S3에 삭제 요청하는 메서드 구현

## 참고 사항

## 관련 이슈
Close #48 
