### PR TITLE
[Feat] #44 공동구매, 중고거래에서 이미지 사용코드 추가 구현완료

### DIFF
--- a/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
+++ b/src/main/java/fc/server/palette/_common/s3/S3ImageUploader.java
@@ -67,7 +67,8 @@ public class S3ImageUploader {
         List<String> paths = removeEndpoint(removeUrls);
 
         List<ObjectIdentifier> objectIdentifiers = new ArrayList<>();
-        paths.forEach(path -> objectIdentifiers.add(ObjectIdentifier.builder().key(path).build()));
+        paths
+                .forEach(path -> objectIdentifiers.add(ObjectIdentifier.builder().key(path).build()));
 
         DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
                 .bucket(bucketName)

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -80,7 +80,7 @@ public class PurchaseController {
     @PatchMapping(value = "/{offerId}", params = {"dto", "removeFileUrl"})
     public ResponseEntity<OfferDto> editOffer(@PathVariable Long offerId,
                                               @RequestPart("dto") EditOfferDto editOfferDto,
-                                              @RequestPart(value = "file", required = false) List<MultipartFile> images,
+                                              @RequestPart(value = "file",  required = false) List<MultipartFile> images,
                                               @RequestPart("removeFileUrl") RemoveImageDto removeImageDto,
                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
         userDetails.validateAuthority(purchaseService.getAuthorId(offerId));

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -90,8 +90,7 @@ public class PurchaseController {
         //s3삭제
         s3ImageUploader.remove(removeImageDto.getUrls());
         //db삭제
-        List<Media> removeMediaList = toMediaList(removeImageDto.getUrls(), purchaseService.getPurchase(offerId));
-        purchaseService.deleteImages(removeMediaList);
+        purchaseService.deleteImages(removeImageDto.getUrls());
 
         //이미지 외 콘텐츠 수정
         OfferDto offer = purchaseService.editOffer(offerId, editOfferDto);
@@ -122,11 +121,11 @@ public class PurchaseController {
         return new ResponseEntity<>(offer, HttpStatus.OK);
     }
 
-    private void saveImages(List<MultipartFile> images, Long offerId){
+    private void saveImages(List<MultipartFile> images, Long offerId) {
         if (images != null) {
             //s3 저장
             List<String> savedImageUrls = s3ImageUploader.save(S3DirectoryNames.PURCHASE, images);
-            //db 저장(toMediaList, purchaseService.saveImages)
+            //db 저장
             List<Media> MediaList = toMediaList(savedImageUrls, purchaseService.getPurchase(offerId));
             purchaseService.saveImages(MediaList);
         }

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -85,13 +85,7 @@ public class PurchaseController {
                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
         userDetails.validateAuthority(purchaseService.getAuthorId(offerId));
 
-        if (images != null) {
-            //s3 저장
-            List<String> savedImageUrls = s3ImageUploader.save(S3DirectoryNames.PURCHASE, images);
-            //db 저장(toMediaList, purchaseService.saveImages)
-            List<Media> saveMediaList = toMediaList(savedImageUrls, purchaseService.getPurchase(offerId));
-            purchaseService.saveImages(saveMediaList);
-        }
+        saveImages(images, offerId);
 
         //s3삭제
         s3ImageUploader.remove(removeImageDto.getUrls());
@@ -112,13 +106,8 @@ public class PurchaseController {
                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
         userDetails.validateAuthority(purchaseService.getAuthorId(offerId));
 
-        if (images != null) {
-            //s3 저장
-            List<String> savedImageUrls = s3ImageUploader.save(S3DirectoryNames.PURCHASE, images);
-            //db 저장(toMediaList, purchaseService.saveImages)
-            List<Media> saveMediaList = toMediaList(savedImageUrls, purchaseService.getPurchase(offerId));
-            purchaseService.saveImages(saveMediaList);
-        }
+        saveImages(images, offerId);
+
         //이미지 외 콘텐츠 수정
         OfferDto offer = purchaseService.editOffer(offerId, editOfferDto);
 
@@ -131,5 +120,15 @@ public class PurchaseController {
         userDetails.validateAuthority(purchaseService.getAuthorId(offerId));
         OfferDto offer = purchaseService.closeOffer(offerId);
         return new ResponseEntity<>(offer, HttpStatus.OK);
+    }
+
+    private void saveImages(List<MultipartFile> images, Long offerId){
+        if (images != null) {
+            //s3 저장
+            List<String> savedImageUrls = s3ImageUploader.save(S3DirectoryNames.PURCHASE, images);
+            //db 저장(toMediaList, purchaseService.saveImages)
+            List<Media> MediaList = toMediaList(savedImageUrls, purchaseService.getPurchase(offerId));
+            purchaseService.saveImages(MediaList);
+        }
     }
 }

--- a/src/main/java/fc/server/palette/purchase/dto/request/EditOfferDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/request/EditOfferDto.java
@@ -16,7 +16,6 @@ public class EditOfferDto {
     private Date endDate;
     private Integer headCount;
     private Integer price;
-    private List<String> images;
     private String description;
     private ClosingType closingType;
     private String bank;

--- a/src/main/java/fc/server/palette/purchase/dto/request/EditOfferDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/request/EditOfferDto.java
@@ -3,10 +3,8 @@ package fc.server.palette.purchase.dto.request;
 import fc.server.palette.purchase.entity.type.ClosingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.Date;
-import java.util.List;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/fc/server/palette/purchase/dto/request/GroupPurchaseOfferDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/request/GroupPurchaseOfferDto.java
@@ -22,7 +22,6 @@ public class GroupPurchaseOfferDto {
     private String description;
     private Integer price;
     private String shopUrl;
-    private List<String> images;
     private ClosingType closingType;
     private String bank;
     private String accountNumber;

--- a/src/main/java/fc/server/palette/purchase/dto/request/RemoveImageDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/request/RemoveImageDto.java
@@ -1,0 +1,14 @@
+package fc.server.palette.purchase.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RemoveImageDto {
+    private List<String> urls;
+}

--- a/src/main/java/fc/server/palette/purchase/repository/PurchaseMediaRepository.java
+++ b/src/main/java/fc/server/palette/purchase/repository/PurchaseMediaRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface PurchaseMediaRepository extends JpaRepository<Media, Long> {
     List<Media> findAllByPurchase_id(Long purchaseId);
+
+    Media findByUrl(String url);
 }

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -55,6 +55,11 @@ public class PurchaseService {
     }
 
     @Transactional
+    public void deleteImages(List<Media> mediaList){
+        purchaseMediaRepository.deleteAll(mediaList);
+    }
+
+    @Transactional
     public OfferDto createOffer(Purchase purchase, List<Media> mediaList) {
         Purchase savedPurchase = purchaseRepository.save(purchase);
         purchaseMediaRepository.saveAll(mediaList);

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -50,6 +50,11 @@ public class PurchaseService {
     }
 
     @Transactional
+    public void saveImages(List<Media> mediaList){
+        purchaseMediaRepository.saveAll(mediaList);
+    }
+
+    @Transactional
     public OfferDto createOffer(Purchase purchase, List<Media> mediaList) {
         Purchase savedPurchase = purchaseRepository.save(purchase);
         purchaseMediaRepository.saveAll(mediaList);

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -44,19 +44,23 @@ public class PurchaseService {
     }
 
     @Transactional(readOnly = true)
-    public Purchase getPurchase(Long offerId){
+    public Purchase getPurchase(Long offerId) {
         return purchaseRepository.findById(offerId)
                 .orElseThrow(() -> new IllegalArgumentException("공동구매 객체가 존재하지 않습니다."));
     }
 
     @Transactional
-    public void saveImages(List<Media> mediaList){
+    public void saveImages(List<Media> mediaList) {
         purchaseMediaRepository.saveAll(mediaList);
     }
 
     @Transactional
-    public void deleteImages(List<Media> mediaList){
-        purchaseMediaRepository.deleteAll(mediaList);
+    public void deleteImages(List<String> urls) {
+        urls
+                .forEach(url ->
+                        purchaseMediaRepository.delete(
+                                purchaseMediaRepository.findByUrl(url)
+                        ));
     }
 
     @Transactional

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -43,6 +43,12 @@ public class PurchaseService {
         return buildOffer(purchase);
     }
 
+    @Transactional(readOnly = true)
+    public Purchase getPurchase(Long offerId){
+        return purchaseRepository.findById(offerId)
+                .orElseThrow(() -> new IllegalArgumentException("공동구매 객체가 존재하지 않습니다."));
+    }
+
     @Transactional
     public OfferDto createOffer(Purchase purchase, List<Media> mediaList) {
         Purchase savedPurchase = purchaseRepository.save(purchase);

--- a/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
+++ b/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
@@ -78,12 +78,21 @@ public class SecondhandController {
     @PatchMapping(value = "/{productId}", params = {"dto","removeFileUrl"})
     public ResponseEntity<ProductDto> EditProduct(@PathVariable Long productId,
                                                   @RequestBody EditProductDto editProductDto,
+                                                  @RequestPart(value = "file",  required = false) List<MultipartFile> images,
+                                                  @RequestPart("removeFileUrl") RemoveImageDto removeImageDto,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails){
         userDetails.validateAuthority(secondhandService.getAuthorId(productId));
+
+        saveImages(images, productId);
+
+        s3ImageUploader.remove(removeImageDto.getUrls());
+        secondhandService.deleteImages(removeImageDto.getUrls());
+        
         ProductDto product = secondhandService.editProduct(productId, editProductDto);
+
         return new ResponseEntity<>(product, HttpStatus.OK);
     }
-    
+
     private void saveImages(List<MultipartFile> images, Long productId) {
         if (images != null) {
             //s3 저장

--- a/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
+++ b/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
@@ -78,7 +78,7 @@ public class SecondhandController {
 
     @PatchMapping(value = "/{productId}", params = {"dto", "removeFileUrl"})
     public ResponseEntity<ProductDto> EditProduct(@PathVariable Long productId,
-                                                  @RequestBody EditProductDto editProductDto,
+                                                  @RequestPart("dto") EditProductDto editProductDto,
                                                   @RequestPart(value = "file", required = false) List<MultipartFile> images,
                                                   @RequestPart("removeFileUrl") RemoveImageDto removeImageDto,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -96,7 +96,7 @@ public class SecondhandController {
 
     @PatchMapping(value = "/{productId}", params = {"dto"})
     public ResponseEntity<ProductDto> EditProduct(@PathVariable Long productId,
-                                                  @RequestBody EditProductDto editProductDto,
+                                                  @RequestPart("dto") EditProductDto editProductDto,
                                                   @RequestPart(value = "file", required = false) List<MultipartFile> images,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
         userDetails.validateAuthority(secondhandService.getAuthorId(productId));

--- a/src/main/java/fc/server/palette/secondhand/dto/request/CreateProductDto.java
+++ b/src/main/java/fc/server/palette/secondhand/dto/request/CreateProductDto.java
@@ -19,7 +19,6 @@ public class CreateProductDto {
     private Time transactionStartTime;
     private Time transactionEndTime;
     //todo 요일 필드
-    private List<String> images;
     private Boolean isFree;
     private String description;
     private Integer price;

--- a/src/main/java/fc/server/palette/secondhand/dto/request/EditProductDto.java
+++ b/src/main/java/fc/server/palette/secondhand/dto/request/EditProductDto.java
@@ -11,11 +11,9 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class EditProductDto {
-    //todo 협의 후 추가하거나 뺄 필드들은 수정 요망
     private Integer price;
     private Time transactionStartTime;
     private Time transactionEndTime;
-    private List<String> images;
     private String description;
 }
 

--- a/src/main/java/fc/server/palette/secondhand/repository/SecondhandMediaRepository.java
+++ b/src/main/java/fc/server/palette/secondhand/repository/SecondhandMediaRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface SecondhandMediaRepository extends JpaRepository<Media, Long> {
     List<Media> findAllBySecondhand_id(Long secondhandId);
+
+    Media findByUrl(String url);
 }

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -46,6 +46,11 @@ public class SecondhandService {
     }
 
     @Transactional
+    public void saveImages(List<Media> mediaList){
+        secondhandMediaRepository.saveAll(mediaList);
+    }
+
+    @Transactional
     public void deleteProduct(Long productId) {
         secondhandRespository.deleteById(productId);
     }

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,14 +39,23 @@ public class SecondhandService {
     }
 
     @Transactional(readOnly = true)
-    public Secondhand getSecondhand(Long productId){
+    public Secondhand getSecondhand(Long productId) {
         return secondhandRespository.findById(productId)
-                .orElseThrow(()-> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
     }
 
     @Transactional
-    public void saveImages(List<Media> mediaList){
+    public void saveImages(List<Media> mediaList) {
         secondhandMediaRepository.saveAll(mediaList);
+    }
+
+    @Transactional
+    public void deleteImages(List<String> urls) {
+        urls
+                .forEach(url ->
+                        secondhandMediaRepository.delete(
+                                secondhandMediaRepository.findByUrl(url)
+                        ));
     }
 
     @Transactional
@@ -56,7 +64,7 @@ public class SecondhandService {
     }
 
     @Transactional
-    public ProductDto closeTransaction(Long productId){
+    public ProductDto closeTransaction(Long productId) {
         Secondhand product = secondhandRespository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
         product.closeTransaction();
@@ -64,16 +72,16 @@ public class SecondhandService {
     }
 
     @Transactional
-    public ProductDto createProduct(Secondhand secondhand, List<Media> mediaList){
+    public ProductDto createProduct(Secondhand secondhand, List<Media> mediaList) {
         Secondhand savedProduct = secondhandRespository.save(secondhand);
         secondhandMediaRepository.saveAll(mediaList);
         return buildProductDto(savedProduct);
     }
 
     @Transactional
-    public ProductDto editProduct(Long productId, EditProductDto editProductDto){
+    public ProductDto editProduct(Long productId, EditProductDto editProductDto) {
         Secondhand product = secondhandRespository.findById(productId)
-                .orElseThrow(()->new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
         product.updateProduct(editProductDto);
         return buildProductDto(product);
     }
@@ -121,9 +129,9 @@ public class SecondhandService {
     }
 
     @Transactional(readOnly = true)
-    public Long getAuthorId(Long productId){
+    public Long getAuthorId(Long productId) {
         Secondhand product = secondhandRespository.findById(productId)
-                .orElseThrow(()-> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
         return product.getMember().getId();
     }
 

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -39,6 +39,12 @@ public class SecondhandService {
         return buildProductDto(product);
     }
 
+    @Transactional(readOnly = true)
+    public Secondhand getSecondhand(Long productId){
+        return secondhandRespository.findById(productId)
+                .orElseThrow(()-> new IllegalArgumentException("중고거래 객체가 존재하지 않습니다."));
+    }
+
     @Transactional
     public void deleteProduct(Long productId) {
         secondhandRespository.deleteById(productId);


### PR DESCRIPTION
## 🧑‍💻 요약
- 공동구매, 중고거래 게시물을 수정할 때 이미지 추가 및 삭제 시 s3저장소와 db에 모두 반영되도록 구현했습니다.

## ✅ 작업 내용(공동구매 + 중고거래)
- [x] 이미지 리스트(file), json 데이터, 삭제 이미지 url 리스트를 받는 컨트롤러 구현
- [x] 수정된 이미지 저장, 삭제를 위한 서비스 메서드 구현
- [x] url을 받아 Media객체를 반환하는 repository메서드 구현
- [x] 삭제 이미지 url리스트를 받는 dto생성

## 참고 사항

## 관련 이슈
Close #44 
