### PR TITLE
[Feat] #56 공동구매, 중고거래 추가 API 구현 완료

### DIFF
--- a/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
+++ b/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
@@ -11,4 +11,5 @@ public class ExceptionMessage {
     public static final String PARTICIPATE_YOURSELF_DENIED = "자신의 게시물에 직접 참여할 수 없습니다.";
     public static final String NO_DUPLICATED_LIKE = "이미 좋아요를 눌렀습니다.";
     public static final String NO_DISLIKE = "좋아요를 누른적이 없습니다.";
+    public static final String CANNOT_BOOKMARK_YOURS = "자신의 게시물은 찜할 수 없습니다.";
 }

--- a/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
+++ b/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
@@ -12,4 +12,5 @@ public class ExceptionMessage {
     public static final String NO_DUPLICATED_LIKE = "이미 좋아요를 눌렀습니다.";
     public static final String NO_DISLIKE = "좋아요를 누른적이 없습니다.";
     public static final String CANNOT_BOOKMARK_YOURS = "자신의 게시물은 찜할 수 없습니다.";
+    public static final String BOOKMARK_ALREADY_EXIST = "이미 추가된 북마크입니다.";
 }

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -1,5 +1,6 @@
 package fc.server.palette.purchase.controller;
 
+import fc.server.palette._common.exception.Exception403;
 import fc.server.palette._common.s3.S3DirectoryNames;
 import fc.server.palette._common.s3.S3ImageUploader;
 import fc.server.palette.chat.entity.type.ChatRoomType;
@@ -23,6 +24,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static fc.server.palette._common.exception.message.ExceptionMessage.CANNOT_BOOKMARK_YOURS;
 
 @RestController
 @RequestMapping("/api/groupPurchase")
@@ -69,6 +72,9 @@ public class PurchaseController {
     @PostMapping("/{offerId}/bookmark")
     public ResponseEntity<?> addBookmark(@PathVariable Long offerId,
                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if(userDetails.getMember().getId().equals(purchaseService.getAuthorId(offerId))){
+            throw new Exception403(CANNOT_BOOKMARK_YOURS);
+        }
         purchaseService.addBookmark(offerId, userDetails.getMember());
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -37,8 +37,8 @@ public class PurchaseController {
     private final ChatRoomService chatRoomService;
 
     @GetMapping("")
-    public ResponseEntity<List<OfferListDto>> getAllOffers() {
-        List<OfferListDto> offers = purchaseService.getAllOffers();
+    public ResponseEntity<List<OfferListDto>> getAllOffers(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        List<OfferListDto> offers = purchaseService.getAllOffers(customUserDetails.getMember().getId());
         return new ResponseEntity<>(offers, HttpStatus.OK);
     }
 

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -40,8 +40,9 @@ public class PurchaseController {
     }
 
     @GetMapping("/{offerId}")
-    public ResponseEntity<OfferDto> getOffer(@PathVariable Long offerId) {
-        OfferDto offer = purchaseService.getOffer(offerId);
+    public ResponseEntity<OfferDto> getOffer(@PathVariable Long offerId,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        OfferDto offer = purchaseService.getOffer(offerId, userDetails.getMember().getId());
         return new ResponseEntity<>(offer, HttpStatus.OK);
     }
 
@@ -53,7 +54,7 @@ public class PurchaseController {
         List<String> savedImageUrls = s3ImageUploader.save(S3DirectoryNames.PURCHASE, images);
         List<Media> mediaList = toMediaList(savedImageUrls, purchase);
         OfferDto offer = purchaseService.createOffer(purchase, mediaList);
-        chatRoomService.openGroupChatRoom(offer, userDetails.getMember().getId(),ChatRoomType.PURCHASE);
+        chatRoomService.openGroupChatRoom(offer, userDetails.getMember().getId(), ChatRoomType.PURCHASE);
         return new ResponseEntity<>(offer, HttpStatus.OK);
     }
 

--- a/src/main/java/fc/server/palette/purchase/dto/response/OfferDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/response/OfferDto.java
@@ -31,6 +31,7 @@ public class OfferDto {
     private Boolean isClosing;
     private Integer hits;
     private LocalDateTime created_at;
+    private Boolean isParticipating;
 
     public ChatRoomDetailContentDto toChatRoomInfo() {
         return ChatRoomDetailContentDto.builder()

--- a/src/main/java/fc/server/palette/purchase/dto/response/OfferListDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/response/OfferListDto.java
@@ -17,4 +17,5 @@ public class OfferListDto {
     private String thumbnailUrl;
     private Integer bookmarkCount;
     private Integer hits;
+    private Boolean isBookmarked;
 }

--- a/src/main/java/fc/server/palette/purchase/entity/Bookmark.java
+++ b/src/main/java/fc/server/palette/purchase/entity/Bookmark.java
@@ -24,4 +24,11 @@ public class Bookmark extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Purchase purchase;
+
+    public static Bookmark of(Purchase purchase, Member member){
+        return Bookmark.builder()
+                .purchase(purchase)
+                .member(member)
+                .build();
+    }
 }

--- a/src/main/java/fc/server/palette/purchase/entity/Purchase.java
+++ b/src/main/java/fc/server/palette/purchase/entity/Purchase.java
@@ -115,4 +115,8 @@ public class Purchase extends BaseEntity {
     public void closeOffer() {
         this.isClosing = true;
     }
+
+    public void increaseHit() {
+        this.hits++;
+    }
 }

--- a/src/main/java/fc/server/palette/purchase/repository/PurchaseBookmarkRepository.java
+++ b/src/main/java/fc/server/palette/purchase/repository/PurchaseBookmarkRepository.java
@@ -2,9 +2,13 @@ package fc.server.palette.purchase.repository;
 
 import fc.server.palette.purchase.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PurchaseBookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findAllByPurchase_id(Long productId);
+
+    Optional<Bookmark> findByMemberIdAndPurchaseId(Long memberId, Long purchaseId);
 }

--- a/src/main/java/fc/server/palette/purchase/repository/PurchaseParticipantMemberRepository.java
+++ b/src/main/java/fc/server/palette/purchase/repository/PurchaseParticipantMemberRepository.java
@@ -1,0 +1,10 @@
+package fc.server.palette.purchase.repository;
+
+import fc.server.palette.purchase.entity.ParticipantMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PurchaseParticipantMemberRepository extends JpaRepository<ParticipantMember, Long> {
+    List<ParticipantMember> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -46,6 +46,16 @@ public class PurchaseService {
         return buildOffer(purchase);
     }
 
+    @Transactional
+    public OfferDto getOffer(Long offerId, Long loginMember) {
+        if (!loginMember.equals(getAuthorId(offerId))) {
+            increaseHit(offerId);
+        }
+        Purchase purchase = purchaseRepository.findById(offerId)
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND + offerId));
+        return buildOffer(purchase);
+    }
+
     @Transactional(readOnly = true)
     public Purchase getPurchase(Long offerId) {
         return purchaseRepository.findById(offerId)
@@ -110,7 +120,7 @@ public class PurchaseService {
         Optional<Media> optionalThumbnail = purchaseMediaRepository.findAllByPurchase_id(purchaseId)
                 .stream()
                 .findFirst();
-        if (optionalThumbnail.isPresent()){
+        if (optionalThumbnail.isPresent()) {
             return optionalThumbnail.get().getUrl();
         }
         return ExceptionMessage.OBJECT_NOT_FOUND;
@@ -163,6 +173,12 @@ public class PurchaseService {
                 .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
         purchase.closeOffer();
         return buildOffer(purchase);
+    }
+
+    private void increaseHit(Long offerId) {
+        Purchase purchase = purchaseRepository.findById(offerId)
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
+        purchase.increaseHit();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -48,7 +48,7 @@ public class PurchaseService {
         }
         Purchase purchase = purchaseRepository.findById(offerId)
                 .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND + offerId));
-        return buildOffer(purchase);
+        return buildOffer(purchase, offerId, loginMember);
     }
 
     @Transactional(readOnly = true)
@@ -96,6 +96,28 @@ public class PurchaseService {
                 .isClosing(purchase.getIsClosing())
                 .hits(purchase.getHits())
                 .created_at(purchase.getCreatedAt())
+                .build();
+    }
+
+    private OfferDto buildOffer(Purchase purchase, Long offerId, Long memberId){
+        return OfferDto.builder()
+                .id(purchase.getId())
+                .member(MemberDto.of(purchase.getMember()))
+                .title(purchase.getTitle())
+                .category(purchase.getCategory())
+                .startDate(purchase.getStartDate())
+                .endDate(purchase.getEndDate())
+                .price(purchase.getPrice())
+                .description(purchase.getDescription())
+                .shopUrl(purchase.getShopUrl())
+                .headCount(purchase.getHeadCount())
+                .bookmarkCount(getBookmarkCount(purchase.getId()))
+                .image(getImagesUrl(purchase.getId()))
+                .currentParticipantCount(getCurrentParticipants(purchase.getId()))
+                .isClosing(purchase.getIsClosing())
+                .hits(purchase.getHits())
+                .created_at(purchase.getCreatedAt())
+                .isParticipating(isParticipating(offerId, memberId))
                 .build();
     }
 

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -7,14 +7,8 @@ import fc.server.palette.purchase.dto.request.EditOfferDto;
 import fc.server.palette.purchase.dto.response.MemberDto;
 import fc.server.palette.purchase.dto.response.OfferDto;
 import fc.server.palette.purchase.dto.response.OfferListDto;
-import fc.server.palette.purchase.entity.Bookmark;
-import fc.server.palette.purchase.entity.Media;
-import fc.server.palette.purchase.entity.Purchase;
-import fc.server.palette.purchase.entity.PurchaseParticipant;
-import fc.server.palette.purchase.repository.PurchaseBookmarkRepository;
-import fc.server.palette.purchase.repository.PurchaseMediaRepository;
-import fc.server.palette.purchase.repository.PurchaseParticipantRepository;
-import fc.server.palette.purchase.repository.PurchaseRepository;
+import fc.server.palette.purchase.entity.*;
+import fc.server.palette.purchase.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +24,7 @@ public class PurchaseService {
     private final PurchaseMediaRepository purchaseMediaRepository;
     private final PurchaseBookmarkRepository purchaseBookmarkRepository;
     private final PurchaseParticipantRepository purchaseParticipantRepository;
+    private final PurchaseParticipantMemberRepository purchaseParticipantMemberRepository;
 
     @Transactional(readOnly = true)
     public List<OfferListDto> getAllOffers() {
@@ -173,6 +168,21 @@ public class PurchaseService {
                 .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
         purchase.closeOffer();
         return buildOffer(purchase);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isParticipating(Long productId, Long memberId){
+        List<ParticipantMember> participants = purchaseParticipantMemberRepository.findAllByMemberId(memberId);
+        ParticipantMember participantMember = participants
+                .stream()
+                .filter(participant -> participant
+                        .getPurchaseParticipant()
+                        .getPurchase()
+                        .getId().
+                        equals(productId))
+                .findAny()
+                .orElse(null);
+        return participantMember != null;
     }
 
     private void increaseHit(Long offerId) {

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -1,5 +1,7 @@
 package fc.server.palette.purchase.service;
 
+import fc.server.palette._common.exception.Exception400;
+import fc.server.palette._common.exception.Exception403;
 import fc.server.palette._common.exception.Exception404;
 import fc.server.palette._common.exception.message.ExceptionMessage;
 import fc.server.palette.member.entity.Member;
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static fc.server.palette._common.exception.message.ExceptionMessage.BOOKMARK_ALREADY_EXIST;
 
 @Service
 @RequiredArgsConstructor
@@ -161,6 +165,11 @@ public class PurchaseService {
 
     @Transactional
     public void addBookmark(Long offerId, Member member) {
+        Bookmark bookmark = purchaseBookmarkRepository.findByMemberIdAndPurchaseId(member.getId(), offerId)
+                .orElse(null);
+        if(bookmark!=null){
+            throw new Exception400(offerId.toString(),BOOKMARK_ALREADY_EXIST);
+        }
         purchaseBookmarkRepository.save(Bookmark.of(getPurchase(offerId), member));
     }
 

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -166,9 +166,7 @@ public class PurchaseService {
 
     @Transactional
     public void addBookmark(Long offerId, Member member) {
-        Bookmark bookmark = purchaseBookmarkRepository.findByMemberIdAndPurchaseId(member.getId(), offerId)
-                .orElse(null);
-        if(bookmark!=null){
+        if(isBookmarked(offerId, member.getId())){
             throw new Exception400(offerId.toString(),BOOKMARK_ALREADY_EXIST);
         }
         purchaseBookmarkRepository.save(Bookmark.of(getPurchase(offerId), member));

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -161,14 +161,7 @@ public class PurchaseService {
 
     @Transactional
     public void addBookmark(Long offerId, Member member) {
-        Purchase purchase = purchaseRepository.findById(offerId)
-                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
-
-        Bookmark bookmark = Bookmark.builder()
-                .member(member)
-                .purchase(purchase)
-                .build();
-        purchaseBookmarkRepository.save(bookmark);
+        purchaseBookmarkRepository.save(Bookmark.of(getPurchase(offerId), member));
     }
 
     @Transactional

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -170,8 +170,7 @@ public class PurchaseService {
         return buildOffer(purchase);
     }
 
-    @Transactional(readOnly = true)
-    public boolean isParticipating(Long productId, Long memberId){
+    private boolean isParticipating(Long offerId, Long memberId){
         List<ParticipantMember> participants = purchaseParticipantMemberRepository.findAllByMemberId(memberId);
         ParticipantMember participantMember = participants
                 .stream()
@@ -179,7 +178,7 @@ public class PurchaseService {
                         .getPurchaseParticipant()
                         .getPurchase()
                         .getId().
-                        equals(productId))
+                        equals(offerId))
                 .findAny()
                 .orElse(null);
         return participantMember != null;

--- a/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
+++ b/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
@@ -36,8 +36,9 @@ public class SecondhandController {
     }
 
     @GetMapping("/{productId}")
-    public ResponseEntity<ProductDto> getProduct(@PathVariable Long productId) {
-        ProductDto product = secondhandService.getProduct(productId);
+    public ResponseEntity<ProductDto> getProduct(@PathVariable Long productId,
+                                                 @AuthenticationPrincipal CustomUserDetails userDetails) {
+        ProductDto product = secondhandService.getProduct(productId, userDetails.getMember().getId());
         return new ResponseEntity<>(product, HttpStatus.OK);
     }
 

--- a/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
+++ b/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
@@ -34,8 +34,8 @@ public class SecondhandController {
     private final S3ImageUploader s3ImageUploader;
 
     @GetMapping("")
-    public ResponseEntity<List<ProductListDto>> getAllProducts() {
-        List<ProductListDto> products = secondhandService.getAllProducts();
+    public ResponseEntity<List<ProductListDto>> getAllProducts(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<ProductListDto> products = secondhandService.getAllProducts(userDetails.getMember().getId());
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 

--- a/src/main/java/fc/server/palette/secondhand/dto/response/AnotherProductDto.java
+++ b/src/main/java/fc/server/palette/secondhand/dto/response/AnotherProductDto.java
@@ -1,0 +1,25 @@
+package fc.server.palette.secondhand.dto.response;
+
+import fc.server.palette.secondhand.entity.Secondhand;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AnotherProductDto {
+    private Long id;
+    private String title;
+    private Integer price;
+    private String thumbnailUrl;
+
+    public static AnotherProductDto of(Secondhand secondhand, String thumbnailUrl){
+        return AnotherProductDto.builder()
+                .id(secondhand.getId())
+                .title(secondhand.getTitle())
+                .price(secondhand.getPrice())
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+}

--- a/src/main/java/fc/server/palette/secondhand/dto/response/ProductDto.java
+++ b/src/main/java/fc/server/palette/secondhand/dto/response/ProductDto.java
@@ -30,7 +30,7 @@ public class ProductDto {
     private Boolean isSoldOut;
     private Boolean isFree;
     private LocalDateTime createdAt;
-
+    private List<AnotherProductDto> anotherProductDtos;
     public ChatRoomDetailContentDto toChatRoomInfo() {
         return ChatRoomDetailContentDto.builder()
                 .contentId(id)

--- a/src/main/java/fc/server/palette/secondhand/dto/response/ProductListDto.java
+++ b/src/main/java/fc/server/palette/secondhand/dto/response/ProductListDto.java
@@ -16,4 +16,5 @@ public class ProductListDto {
     private String thumbnailUrl;
     private Integer bookmarkCount;
     private Integer hits;
+    private Boolean isBookmarked;
 }

--- a/src/main/java/fc/server/palette/secondhand/entity/Bookmark.java
+++ b/src/main/java/fc/server/palette/secondhand/entity/Bookmark.java
@@ -24,4 +24,11 @@ public class Bookmark extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Secondhand secondhand;
+
+    public static Bookmark of(Secondhand secondhand, Member member){
+        return Bookmark.builder()
+                .secondhand(secondhand)
+                .member(member)
+                .build();
+    }
 }

--- a/src/main/java/fc/server/palette/secondhand/entity/Secondhand.java
+++ b/src/main/java/fc/server/palette/secondhand/entity/Secondhand.java
@@ -90,4 +90,8 @@ public class Secondhand extends BaseEntity {
         this.transactionEndTime = editProductDto.getTransactionEndTime();
         this.description = editProductDto.getDescription();
     }
+
+    public void increaseHit() {
+        this.hits++;
+    }
 }

--- a/src/main/java/fc/server/palette/secondhand/repository/SecondhandBookmarkRepository.java
+++ b/src/main/java/fc/server/palette/secondhand/repository/SecondhandBookmarkRepository.java
@@ -4,7 +4,10 @@ import fc.server.palette.secondhand.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SecondhandBookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findAllBySecondhand_id(Long secondhandId);
+    Optional<Bookmark> findByMemberIdAndSecondhandId(Long memberId, Long secondhandId);
+
 }

--- a/src/main/java/fc/server/palette/secondhand/repository/SecondhandRespository.java
+++ b/src/main/java/fc/server/palette/secondhand/repository/SecondhandRespository.java
@@ -2,6 +2,12 @@ package fc.server.palette.secondhand.repository;
 
 import fc.server.palette.secondhand.entity.Secondhand;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface SecondhandRespository extends JpaRepository<Secondhand, Long> {
+
+    @Query("select s from Secondhand s where s.member.id = ?1 and s.id <> ?2")
+    List<Secondhand> findAllByMemberIdAndExcludeId(Long memberId, Long idToExclude);
 }

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -4,6 +4,7 @@ import fc.server.palette._common.exception.Exception404;
 import fc.server.palette._common.exception.message.ExceptionMessage;
 import fc.server.palette.purchase.dto.response.MemberDto;
 import fc.server.palette.secondhand.dto.request.EditProductDto;
+import fc.server.palette.secondhand.dto.response.AnotherProductDto;
 import fc.server.palette.secondhand.dto.response.ProductDto;
 import fc.server.palette.secondhand.dto.response.ProductListDto;
 import fc.server.palette.secondhand.entity.Media;
@@ -133,7 +134,15 @@ public class SecondhandService {
                 .isSoldOut(secondhand.getIsSoldOut())
                 .isFree(secondhand.getIsFree())
                 .createdAt(secondhand.getCreatedAt())
+                .anotherProductDtos(getAnotherProducts(secondhand.getMember().getId(), secondhand.getId()))
                 .build();
+    }
+    private List<AnotherProductDto> getAnotherProducts(Long memberId, Long productId){
+        List<Secondhand> anotherProducts = secondhandRespository.findAllByMemberIdAndExcludeId(memberId, productId);
+        return anotherProducts
+                .stream()
+                .map(anotherProduct -> AnotherProductDto.of(anotherProduct, getThumbnailUrl(anotherProduct.getId())))
+                .collect(Collectors.toList());
     }
 
     private String getThumbnailUrl(Long secondhandId) {

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -1,5 +1,6 @@
 package fc.server.palette.secondhand.service;
 
+import fc.server.palette._common.exception.Exception400;
 import fc.server.palette._common.exception.Exception404;
 import fc.server.palette._common.exception.message.ExceptionMessage;
 import fc.server.palette.member.entity.Member;
@@ -21,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static fc.server.palette._common.exception.message.ExceptionMessage.BOOKMARK_ALREADY_EXIST;
 
 @Service
 @RequiredArgsConstructor
@@ -139,7 +142,8 @@ public class SecondhandService {
                 .anotherProductDtos(getAnotherProducts(secondhand.getMember().getId(), secondhand.getId()))
                 .build();
     }
-    private List<AnotherProductDto> getAnotherProducts(Long memberId, Long productId){
+
+    private List<AnotherProductDto> getAnotherProducts(Long memberId, Long productId) {
         List<Secondhand> anotherProducts = secondhandRespository.findAllByMemberIdAndExcludeId(memberId, productId);
         return anotherProducts
                 .stream()
@@ -165,7 +169,12 @@ public class SecondhandService {
     }
 
     @Transactional
-    public void addBookmark(Long productId, Member member){
+    public void addBookmark(Long productId, Member member) {
+        Bookmark bookmark = secondhandBookmarkRepository.findByMemberIdAndSecondhandId(member.getId(), productId)
+                .orElse(null);
+        if (bookmark != null) {
+            throw new Exception400(productId.toString(), BOOKMARK_ALREADY_EXIST);
+        }
         secondhandBookmarkRepository.save(Bookmark.of(getSecondhand(productId), member));
     }
 

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -42,6 +42,22 @@ public class SecondhandService {
     }
 
     @Transactional(readOnly = true)
+    public ProductDto getProduct(Long productId, Long loginMember) {
+        if (!loginMember.equals(getAuthorId(productId))) {
+            increaseHit(productId);
+        }
+        Secondhand product = secondhandRespository.findById(productId)
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
+        return buildProductDto(product);
+    }
+
+    private void increaseHit(Long productId) {
+        Secondhand secondhand = secondhandRespository.findById(productId)
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
+        secondhand.increaseHit();
+    }
+
+    @Transactional(readOnly = true)
     public Secondhand getSecondhand(Long productId) {
         return secondhandRespository.findById(productId)
                 .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
@@ -124,7 +140,7 @@ public class SecondhandService {
         Optional<Media> optionalThumbnail = secondhandMediaRepository.findAllBySecondhand_id(secondhandId)
                 .stream()
                 .findFirst();
-        if (optionalThumbnail.isPresent()){
+        if (optionalThumbnail.isPresent()) {
             return optionalThumbnail.get().getUrl();
         }
         return ExceptionMessage.OBJECT_NOT_FOUND;

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -2,11 +2,13 @@ package fc.server.palette.secondhand.service;
 
 import fc.server.palette._common.exception.Exception404;
 import fc.server.palette._common.exception.message.ExceptionMessage;
+import fc.server.palette.member.entity.Member;
 import fc.server.palette.purchase.dto.response.MemberDto;
 import fc.server.palette.secondhand.dto.request.EditProductDto;
 import fc.server.palette.secondhand.dto.response.AnotherProductDto;
 import fc.server.palette.secondhand.dto.response.ProductDto;
 import fc.server.palette.secondhand.dto.response.ProductListDto;
+import fc.server.palette.secondhand.entity.Bookmark;
 import fc.server.palette.secondhand.entity.Media;
 import fc.server.palette.secondhand.entity.Secondhand;
 import fc.server.palette.secondhand.repository.SecondhandBookmarkRepository;
@@ -160,6 +162,11 @@ public class SecondhandService {
         Secondhand product = secondhandRespository.findById(productId)
                 .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
         return product.getMember().getId();
+    }
+
+    @Transactional
+    public void addBookmark(Long productId, Member member){
+        secondhandBookmarkRepository.save(Bookmark.of(getSecondhand(productId), member));
     }
 
     private List<String> getImagesUrl(Long secondhandId) {


### PR DESCRIPTION
## 🧑‍💻 요약
- 조회수 증가 api
- (공동구매)참여여부 기능 추가
- (중고거래)판매자의 다른 상품 api
- 상품 리스트 좋아요 표시 기능 추가
- 공동구매, 중고거래 북마크 API 구현

## ✅ 작업 내용
- [x] **조회수 증가**: 로그인된 유저를 제외한 다른 유저가 게시물 상세보기 접근 시 hits++
- [x] **(공동구매) 참여여부**: 로그인된 유저가 상세보기에 접근했을 때 그 공동구매에 참여중인지 여부를 dto필드로 추가해 함께 응답
- [x] **(중고거래)판매자의 다른 상품**: 상세보기 응답에 중고거래 작성자의 다른 상품도 포함되도록 수정. 
- [x] **공동구매, 중고거래 북마크 API 구현**
- [x] **상품 리스트 좋아요 표시**: 로그인된 사용자가 북마크한 게시글은 리스트 응답 시 해당 필드를 true로 반환하도록 함

## 참고 사항

## 관련 이슈
Close #56
