### PR TITLE
[Feat] 참여하기 API, 공동구매 및 중고거래 리스트에 마감여부 필드 추가 구현 완료

### DIFF
--- a/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
+++ b/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
@@ -13,6 +13,7 @@ public class ExceptionMessage {
     public static final String NO_DISLIKE = "좋아요를 누른적이 없습니다.";
     public static final String CANNOT_BOOKMARK_YOURS = "자신의 게시물은 찜할 수 없습니다.";
     public static final String BOOKMARK_ALREADY_EXIST = "이미 추가된 북마크입니다.";
+    public static final String PARTICIPANT_ALREADY_EXIST = "이미 참여중인 공동구매입니다.";
     public static final String FOLLOWED_FOLLOWING_EXIST = "해당 팔로우 팔로워 관계가 이미 존재합니다.";
     public static final String CANNOT_FOLLOWING_YOURSELF = "나 자신을 팔로우 할 수 없습니다.";
 }

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -131,6 +131,14 @@ public class PurchaseController {
         return new ResponseEntity<>(offer, HttpStatus.OK);
     }
 
+    @PostMapping("{offerId}/participate")
+    public ResponseEntity<?> participateOffer(@PathVariable Long offerId,
+                                                @AuthenticationPrincipal CustomUserDetails userDetails){
+        purchaseService.participateOffer(offerId, userDetails.getMember());
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     private void saveImages(List<MultipartFile> images, Long offerId) {
         if (images != null) {
             //s3 저장

--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -56,7 +56,7 @@ public class PurchaseController {
         Purchase purchase = groupPurchaseOfferDto.toEntity(userDetails.getMember());
         List<String> savedImageUrls = s3ImageUploader.save(S3DirectoryNames.PURCHASE, images);
         List<Media> mediaList = toMediaList(savedImageUrls, purchase);
-        OfferDto offer = purchaseService.createOffer(purchase, mediaList);
+        OfferDto offer = purchaseService.createOffer(purchase, userDetails.getMember(), mediaList);
         chatRoomService.openGroupChatRoom(offer, userDetails.getMember().getId(), ChatRoomType.PURCHASE);
         return new ResponseEntity<>(offer, HttpStatus.OK);
     }

--- a/src/main/java/fc/server/palette/purchase/dto/response/OfferListDto.java
+++ b/src/main/java/fc/server/palette/purchase/dto/response/OfferListDto.java
@@ -18,4 +18,5 @@ public class OfferListDto {
     private Integer bookmarkCount;
     private Integer hits;
     private Boolean isBookmarked;
+    private Boolean isclosing;
 }

--- a/src/main/java/fc/server/palette/purchase/entity/ParticipantMember.java
+++ b/src/main/java/fc/server/palette/purchase/entity/ParticipantMember.java
@@ -24,4 +24,11 @@ public class ParticipantMember {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private PurchaseParticipant purchaseParticipant;
+
+    public static ParticipantMember of(Member member, PurchaseParticipant purchaseParticipant){
+        return ParticipantMember.builder()
+                .member(member)
+                .purchaseParticipant(purchaseParticipant)
+                .build();
+    }
 }

--- a/src/main/java/fc/server/palette/purchase/entity/PurchaseParticipant.java
+++ b/src/main/java/fc/server/palette/purchase/entity/PurchaseParticipant.java
@@ -25,4 +25,10 @@ public class PurchaseParticipant extends BaseEntity {
 
     @OneToMany(mappedBy = "purchaseParticipant", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ParticipantMember> participantMemberList;
+
+    public static PurchaseParticipant of(Purchase purchase){
+        return PurchaseParticipant.builder()
+                .purchase(purchase)
+                .build();
+    }
 }

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -202,6 +202,15 @@ public class PurchaseService {
 
     @Transactional
     public void participateOffer(Long offerId, Member member){
+        List<ParticipantMember> participants = purchaseParticipantMemberRepository.findAllByMemberId(member.getId());
+        ParticipantMember participant = participants
+                .stream()
+                .filter(participantMember -> participantMember.getPurchaseParticipant().getPurchase().getId().equals(offerId))
+                .findAny()
+                .orElse(null);
+        if(participant!=null){
+            throw new Exception400(offerId.toString(), ExceptionMessage.PARTICIPANT_ALREADY_EXIST);
+        }
         PurchaseParticipant purchaseParticipant = PurchaseParticipant.of(getPurchase(offerId));
         purchaseParticipantRepository.save(purchaseParticipant);
         ParticipantMember participantMember = ParticipantMember.of(member, purchaseParticipant);

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -76,8 +76,9 @@ public class PurchaseService {
     }
 
     @Transactional
-    public OfferDto createOffer(Purchase purchase, List<Media> mediaList) {
+    public OfferDto createOffer(Purchase purchase, Member member,List<Media> mediaList) {
         Purchase savedPurchase = purchaseRepository.save(purchase);
+        participateOffer(purchase.getId(), member);
         purchaseMediaRepository.saveAll(mediaList);
         return buildOffer(savedPurchase);
     }

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -201,13 +201,7 @@ public class PurchaseService {
 
     @Transactional
     public void participateOffer(Long offerId, Member member){
-        List<ParticipantMember> participants = purchaseParticipantMemberRepository.findAllByMemberId(member.getId());
-        ParticipantMember participant = participants
-                .stream()
-                .filter(participantMember -> participantMember.getPurchaseParticipant().getPurchase().getId().equals(offerId))
-                .findAny()
-                .orElse(null);
-        if(participant!=null){
+        if(isParticipating(offerId, member.getId())){
             throw new Exception400(offerId.toString(), ExceptionMessage.PARTICIPANT_ALREADY_EXIST);
         }
         PurchaseParticipant purchaseParticipant = PurchaseParticipant.of(getPurchase(offerId));

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -135,6 +135,7 @@ public class PurchaseService {
                 .bookmarkCount(getBookmarkCount(purchase.getId()))
                 .hits(purchase.getHits())
                 .isBookmarked(isBookmarked)
+                .isclosing(purchase.getIsClosing())
                 .build();
     }
 

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -1,7 +1,6 @@
 package fc.server.palette.purchase.service;
 
 import fc.server.palette._common.exception.Exception400;
-import fc.server.palette._common.exception.Exception403;
 import fc.server.palette._common.exception.Exception404;
 import fc.server.palette._common.exception.message.ExceptionMessage;
 import fc.server.palette.member.entity.Member;
@@ -41,7 +40,7 @@ public class PurchaseService {
     @Transactional(readOnly = true)
     public OfferDto getOffer(Long offerId) {
         Purchase purchase = purchaseRepository.findById(offerId)
-                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND + offerId));
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
         return buildOffer(purchase);
     }
 
@@ -51,14 +50,14 @@ public class PurchaseService {
             increaseHit(offerId);
         }
         Purchase purchase = purchaseRepository.findById(offerId)
-                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND + offerId));
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
         return buildOffer(purchase, offerId, loginMember);
     }
 
     @Transactional(readOnly = true)
     public Purchase getPurchase(Long offerId) {
         return purchaseRepository.findById(offerId)
-                .orElseThrow(() -> new IllegalArgumentException("공동구매 객체가 존재하지 않습니다."));
+                .orElseThrow(() -> new Exception404(ExceptionMessage.OBJECT_NOT_FOUND));
     }
 
     @Transactional

--- a/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
+++ b/src/main/java/fc/server/palette/purchase/service/PurchaseService.java
@@ -199,6 +199,14 @@ public class PurchaseService {
         return buildOffer(purchase);
     }
 
+    @Transactional
+    public void participateOffer(Long offerId, Member member){
+        PurchaseParticipant purchaseParticipant = PurchaseParticipant.of(getPurchase(offerId));
+        purchaseParticipantRepository.save(purchaseParticipant);
+        ParticipantMember participantMember = ParticipantMember.of(member, purchaseParticipant);
+        purchaseParticipantMemberRepository.save(participantMember);
+    }
+
     private boolean isParticipating(Long offerId, Long memberId){
         List<ParticipantMember> participants = purchaseParticipantMemberRepository.findAllByMemberId(memberId);
         ParticipantMember participantMember = participants

--- a/src/main/java/fc/server/palette/secondhand/dto/response/ProductListDto.java
+++ b/src/main/java/fc/server/palette/secondhand/dto/response/ProductListDto.java
@@ -17,4 +17,5 @@ public class ProductListDto {
     private Integer bookmarkCount;
     private Integer hits;
     private Boolean isBookmarked;
+    private Boolean isSoldOut;
 }

--- a/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
+++ b/src/main/java/fc/server/palette/secondhand/service/SecondhandService.java
@@ -121,6 +121,7 @@ public class SecondhandService {
                 .bookmarkCount(getBookmarkCount(secondhand.getId()))
                 .hits(secondhand.getHits())
                 .isBookmarked(isBookmarked)
+                .isSoldOut(secondhand.getIsSoldOut())
                 .build();
     }
 


### PR DESCRIPTION
## 🧑‍💻 요약
- 공동구매 참여 API 및 공동구매 + 중고거래 리스트에 마감(품절)여부 추가 완료했습니다.

## ✅ 작업 내용
- [x]  현재 로그인된 유저가 참여하기 버튼을 누르면 purchaseParticipant와 purchaseParticipantMember테이블에 db저장
- [x] 공동구매 현재 참여자 ++해서 응답되도록
- [x] 공동구매 리스트 응답에 마감여부 필드 추가
- [x] 중고거래 리스트 응답에 마감여부 필드 추가

## 참고 사항

## 관련 이슈
Close #이슈번호
