### PR TITLE
[Refactor] #83  팔로우관계관련 예외처리 수정및 기능추가

### DIFF
--- a/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
+++ b/src/main/java/fc/server/palette/_common/exception/message/ExceptionMessage.java
@@ -11,7 +11,6 @@ public class ExceptionMessage {
     public static final String PARTICIPATE_YOURSELF_DENIED = "자신의 게시물에 직접 참여할 수 없습니다.";
     public static final String NO_DUPLICATED_LIKE = "이미 좋아요를 눌렀습니다.";
     public static final String NO_DISLIKE = "좋아요를 누른적이 없습니다.";
-    public static final String FOLLOWED_FOLLOWING_EXIST = "해당 팔로우 팔로워 관계가 이미존재합니다.";
     public static final String CANNOT_FOLLOWING_YOURSELF = "나 자신을 팔로우 할 수 없습니다.";
 
 }

--- a/src/main/java/fc/server/palette/member/dto/response/FollowInfoDto.java
+++ b/src/main/java/fc/server/palette/member/dto/response/FollowInfoDto.java
@@ -10,7 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FollowInfoDto {
+
+    private Long memberId;
     private String image;
     private String nickname;
     private String bio;
+
+
 }

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -219,6 +219,7 @@ public class MemberService {
 
     public FollowInfoDto followInfo(Member member) {
         return new FollowInfoDto().builder()
+                .memberId(member.getId())
                 .image(member.getImage())
                 .nickname(member.getNickname())
                 .bio(member.getBio())

--- a/src/main/java/fc/server/palette/member/service/MemberService.java
+++ b/src/main/java/fc/server/palette/member/service/MemberService.java
@@ -175,9 +175,6 @@ public class MemberService {
                     .following(memberRepository.getReferenceById(followingId))
                     .build();
             followRepository.save(follow);
-        } else {
-            throw new Exception404(ExceptionMessage.FOLLOWED_FOLLOWING_EXIST);
-
         }
 
         if(followedId.equals(followingId)) {


### PR DESCRIPTION
## 🧑‍💻 요약
- 팔로우관계관련 예외처리를 삭제하고, 팔로우,팔로워리스트상에 memberId값도 표기할 수 있도록 수정합니다.

## ✅ 작업 내용
- [x] 팔로우관계관련 예외처리 삭제
- [x] 팔로워 팔로우리스트에 memberId값 추가

## 참고 사항

## 관련 이슈

