### PR TITLE
[Fix] 공동구매 수정, 중고거래 수정 버그 수정

### DIFF
--- a/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
+++ b/src/main/java/fc/server/palette/purchase/controller/PurchaseController.java
@@ -23,7 +23,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -89,7 +88,7 @@ public class PurchaseController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @PostMapping(value = "/{offerId}", params = {"dto", "removeFileUrl"})
+    @PostMapping(value = "/{offerId}", params = "removeImage=true")
     public ResponseEntity<OfferDto> editOffer(@PathVariable Long offerId,
                                               @RequestPart("dto") EditOfferDto editOfferDto,
                                               @RequestPart(value = "file", required = false) List<MultipartFile> images,
@@ -110,7 +109,7 @@ public class PurchaseController {
         return new ResponseEntity<>(offer, HttpStatus.OK);
     }
 
-    @PostMapping(value = "/{offerId}", params = {"dto"})
+    @PostMapping(value = "/{offerId}")
     public ResponseEntity<OfferDto> editOffer(@PathVariable Long offerId,
                                               @RequestPart("dto") EditOfferDto editOfferDto,
                                               @RequestPart(value = "file", required = false) List<MultipartFile> images,

--- a/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
+++ b/src/main/java/fc/server/palette/secondhand/controller/SecondhandController.java
@@ -82,7 +82,7 @@ public class SecondhandController {
                 .collect(Collectors.toList());
     }
 
-    @PostMapping(value = "/{productId}", params = {"dto", "removeFileUrl"})
+    @PostMapping(value = "/{productId}", params = "removeImage=true")
     public ResponseEntity<ProductDto> editProduct(@PathVariable Long productId,
                                                   @RequestPart("dto") EditProductDto editProductDto,
                                                   @RequestPart(value = "file", required = false) List<MultipartFile> images,
@@ -100,7 +100,7 @@ public class SecondhandController {
         return new ResponseEntity<>(product, HttpStatus.OK);
     }
 
-    @PostMapping(value = "/{productId}", params = {"dto"})
+    @PostMapping(value = "/{productId}")
     public ResponseEntity<ProductDto> editProduct(@PathVariable Long productId,
                                                   @RequestPart("dto") EditProductDto editProductDto,
                                                   @RequestPart(value = "file", required = false) List<MultipartFile> images,


### PR DESCRIPTION
## 🧑‍💻 요약
- API요청 시 올바르지 않은 parameter 오류 발생하는 부분 해결

## ✅ 작업 내용
- [x] 공동구매 수정(image삭제) API 수정: 파라미터 추가 removeImage=true
- [x] 공동구매 수정(image삭제 x) 메서드 수정: @RequestMapping의 params속성 제거
- [x] 중고거래 수정(image삭제) API 수정: 파라미터 추가 removeImage=true
- [x] 중고거래 수정(image삭제 x) 메서드 수정: @RequestMapping의 params속성 제거

## 참고 사항
컨트롤러 메서드의 오버로딩을 위해  @RequestMapping의 params속성을 사용했지만, 쿼리 파라미터를 사용하지 않으면 API요청 시 올바르지 않은 파라미터 오류가 발생하는 것을 발견했습니다. 이에 파라미터를 추가하도록 API를 수정했습니다.

## 관련 이슈
Close #104 
