### PR TITLE
[Fix] 마이페이지 수정 시 필수가 아닌 필드를 누락하고 보내면 오류 발생하는 현상 수정

### DIFF
--- a/src/main/java/fc/server/palette/member/dto/request/MemberProfileDto.java
+++ b/src/main/java/fc/server/palette/member/dto/request/MemberProfileDto.java
@@ -18,7 +18,7 @@ public class MemberProfileDto {
     private String nickname;
     private String bio;
     private String sex;
-    private String position;
-    private String job;
+    private String position = null;
+    private String job = null;
 
 }


### PR DESCRIPTION
## 🧑‍💻 요약
- MemberProfileDto의 position, job=null로 수정하여 position, job필드가 포함되지 않은 요청의 경우 해당 필드를 원래의 값으로 대체

## 관련 이슈
Close #106 
